### PR TITLE
added methods to implement sql related interfaces.

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -1,0 +1,28 @@
+package semver
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+// Scan implements the database/sql.Scanner interface.
+func (v *Version) Scan(src interface{}) (err error) {
+	var strVal string
+	switch src.(type) {
+	case string:
+		strVal = src.(string)
+	case []byte:
+		strVal = string(src.([]byte))
+	default:
+		return fmt.Errorf("Version.Scan: cannot convert %T to string.", src)
+	}
+
+	v, err = Parse(strVal)
+
+	return
+}
+
+// Value implements the database/sql/driver.Valuer interface.
+func (s Version) Value() (driver.Value, error) {
+	return s.String(), nil
+}

--- a/sql_test.go
+++ b/sql_test.go
@@ -1,0 +1,34 @@
+package semver
+
+import (
+	"testing"
+)
+
+type scanTest struct {
+	val         interface{}
+	shouldError bool
+}
+
+var scanTests = []scanTest{
+	scanTest{"1.2.3", false},
+	scanTest{[]byte("1.2.3"), false},
+	scanTest{7, true},
+	scanTest{7e4, true},
+	scanTest{true, true},
+}
+
+func TestScanString(t *testing.T) {
+	for _, tc := range scanTests {
+		s := &Version{}
+		err := s.Scan(tc.val)
+		if tc.shouldError {
+			if err == nil {
+				t.Fatalf("Scan did not return an error on %v (%T)", tc.val, tc.val)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("Scan returned an unexpected error: %s (%T) on %v (%T)", tc.val, tc.val, tc.val, tc.val)
+			}
+		}
+	}
+}


### PR DESCRIPTION
**Implemented methods:**
- Version.Scan -> database/sql.Scanner
- Version.Value -> database/sql/driver.Valuer

Current implementation stores Version as a single string Field, which is most convenient when it is used as a struct field.

Thx for this awesome package.
Keep up the good work!
