### PR TITLE
fixed Vale.Scan to properly initialise v after call to Parse

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -17,8 +17,11 @@ func (v *Version) Scan(src interface{}) (err error) {
 		return fmt.Errorf("Version.Scan: cannot convert %T to string.", src)
 	}
 
-	v, err = Parse(strVal)
-
+	tmpv, err := Parse(strVal)
+	if err != nil {
+		return
+	}
+	*v = *tmpv
 	return
 }
 


### PR DESCRIPTION
Fixed the implementation of `Value.Scan`.
Tests pass now. Thanks for taking the time, to investigate and spott this.
