### PR TITLE
Start with a slice large enough for the minimum version

### DIFF
--- a/semver.go
+++ b/semver.go
@@ -30,7 +30,7 @@ type Version struct {
 
 // Version to string
 func (v Version) String() string {
-	b := make([]byte, 0)
+	b := make([]byte, 0, 5)
 	b = strconv.AppendUint(b, v.Major, 10)
 	b = append(b, '.')
 	b = strconv.AppendUint(b, v.Minor, 10)

--- a/semver_test.go
+++ b/semver_test.go
@@ -301,6 +301,16 @@ func BenchmarkStringSimple(b *testing.B) {
 	}
 }
 
+func BenchmarkStringLarger(b *testing.B) {
+	const VERSION = "11.15.2012"
+	v, _ := New(VERSION)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		v.String()
+	}
+}
+
 func BenchmarkStringComplex(b *testing.B) {
 	const VERSION = "0.0.1-alpha.preview+123.456"
 	v, _ := New(VERSION)


### PR DESCRIPTION
Obviously, we should make room for (at least) three digits and two dots. I considered padding a little bit more (maybe six digits is common?) but decided against it after some snooping*.

Before:

```
BenchmarkStringSimple   10000000               195 ns/op              16 B/op          1 allocs/op
BenchmarkStringLarger    5000000               326 ns/op              40 B/op          2 allocs/op
BenchmarkStringComplex   5000000               506 ns/op              88 B/op          3 allocs/op
BenchmarkStringAverage   5000000               411 ns/op              56 B/op          2 allocs/op
```

After:

```
BenchmarkStringSimple   20000000               117 ns/op               5 B/op          0 allocs/op
BenchmarkStringLarger   10000000               243 ns/op              32 B/op          2 allocs/op
BenchmarkStringComplex   5000000               446 ns/op              80 B/op          3 allocs/op
BenchmarkStringAverage   5000000               336 ns/op              47 B/op          2 allocs/op
```

\* 81% of the released versions on RubyGems are single digits, and more than 99% fit after one grow.

``` ruby
abort "Requires Ruby 2.x" unless RUBY_VERSION.start_with? '2.'

require 'rubygems/name_tuple'
require 'rubygems/remote_fetcher'

Gem::Source.new('https://rubygems.org').load_specs(:released).each do |tuple|
  puts tuple.version.to_s
end
```

``` sh
ruby rubygems.rb | awk -e '{ print length() }' | sort -n | uniq -c
```
