### PR TITLE
Restrict prerelease version to prerelease ranges

### DIFF
--- a/range.go
+++ b/range.go
@@ -36,9 +36,15 @@ type versionRange struct {
 
 // rangeFunc creates a Range from the given versionRange.
 func (vr *versionRange) rangeFunc() Range {
-	return Range(func(v Version) bool {
-		return vr.c(v, vr.v)
-	})
+	if len(vr.v.Pre) == 0 {
+		return Range(func(v Version) bool {
+			return len(v.Pre) == 0 && vr.c(v, vr.v)
+		})
+	} else {
+		return Range(func(v Version) bool {
+			return prMatch(vr.v, v) && vr.c(v, vr.v)
+		})
+	}
 }
 
 // Range represents a range of versions.
@@ -185,6 +191,15 @@ func splitAndTrim(s string) (result []string) {
 	// 	}
 	// }
 	return
+}
+
+// When checking prerelease ranges, we want to make sure we're
+// only matching against ranges with same [major, minor, patch]
+func prMatch(v, o Version) bool {
+	return len(o.Pre) == 0 || (
+		v.Major == o.Major &&
+		v.Minor == o.Minor &&
+		v.Patch == o.Patch)
 }
 
 // splitComparatorVersion splits the comparator from the version.

--- a/range_test.go
+++ b/range_test.go
@@ -263,6 +263,7 @@ func TestParseRange(t *testing.T) {
 			{"1.2.2", false},
 			{"1.2.3", false},
 			{"1.2.4", true},
+			{"1.2.5-beta", false},
 		}},
 		{">=1.2.3", []tv{
 			{"1.2.3", true},
@@ -304,6 +305,17 @@ func TestParseRange(t *testing.T) {
 			{"1.2.3", false},
 			{"1.2.4", true},
 		}},
+
+		// Prerelease Expression
+		{">=1.4.2-beta.2", []tv{
+			{"1.3.2", false},
+			{"1.4.3", true},
+			{"1.4.0-beta", false},
+			{"1.4.2-beta", false},
+			{"1.4.2-beta.3", true},
+			{"1.4.3-beta", false},
+		}},
+
 		// Simple Expression errors
 		{">>1.2.3", nil},
 		{"!1.2.3", nil},


### PR DESCRIPTION
Currently prerelease versions like `1.2.5-beta` are matched successfully against non-prerelease ranges like `>= 1.2.0`.  This may cause undesired behavior and/or unexpected instability.

This change is to restrict prerelease matches to more closely follow **npm-semver**:
https://github.com/npm/node-semver#prerelease-tags