### PR TITLE
add tolerant parsing functionality for non-standard versions

### DIFF
--- a/semver.go
+++ b/semver.go
@@ -200,6 +200,29 @@ func Make(s string) (Version, error) {
 	return Parse(s)
 }
 
+// ParseTolerant allows for certain version specifications that do not strictly adhere to semver
+// specs to be parsed by this library. It does so by normalizing versions before passing them to
+// Parse(). It currently trims spaces, removes a "v" prefix, and adds a 0 patch number to versions
+// with only major and minor components specified
+func ParseTolerant(s string) (Version, error) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "v")
+
+	// Split into major.minor.(patch+pr+meta)
+	parts := strings.SplitN(s, ".", 3)
+	if len(parts) < 3 {
+		if strings.ContainsAny(parts[len(parts)-1], "+-") {
+			return Version{}, errors.New("Short version cannot contain PreRelease/Build meta data")
+		}
+		for len(parts) < 3 {
+			parts = append(parts, "0")
+		}
+		s = strings.Join(parts, ".")
+	}
+
+	return Parse(s)
+}
+
 // Parse parses version string and returns a validated Version or error
 func Parse(s string) (Version, error) {
 	if len(s) == 0 {


### PR DESCRIPTION
In response to issue https://github.com/blang/semver/issues/16

This adds a `ParseTolerant` function for the handling of versions of the following non-standard forms:
- a "v" prefix, e.g. `v1.0.4`
- spaces surrounding the version
- simple versions without a patch number, e.g. `1.0`, which are given a patch number of `0`

Potential issues:
- Handling for simple versions without a patch number could be slightly more efficient if it was handled within the `Parse` method, but that would make it less strict which is undesired. One possibility would be to replace `Parse(s string)` with a `parse(s string, tolerant bool)` internal function. I'm not super worried about this though, happy to make the change but if you prefer the simplicity of the current version I'm good with that.
- If someone creates a 2-part version with pre/build info, e.g. `1.0-beta.2`, it returns an error. My feeling is that if someone is getting that specific then it's reasonable to expect a patch version. Option here would be to add support for this with a bit more complexity.