### PR TITLE
Add go 1.8, 1.9, 1.10 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: go
 matrix:
   include:
-  - go: 1.4.3
-  - go: 1.5.4
-  - go: 1.6.3
-  - go: 1.7
+  - go: 1.4.x
+  - go: 1.5.x
+  - go: 1.6.x
+  - go: 1.7.x
+  - go: 1.8.x
+  - go: 1.9.x
+  - go: 1.10.x
   - go: tip
   allow_failures:
   - go: tip


### PR DESCRIPTION
I just added missing go 1.8, 1.9, 1.10 to travis! 👍 
Thanks!