### PR TITLE
Enable go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/blang/semver


### PR DESCRIPTION
https://github.com/golang/go/wiki/Modules#gomod

This PR is just a result of the following commands (in clean Go 1.11.5 environment):

```
go mod init
go get ./...
go mod tidy
```

The aim is to prevent `semver` from being marked as "incompatible" in go-mod-aware modules which depend on semver. This happens just because semver is `>1.0.0` (currently `v3.5.1`) but isn't go-mod-aware. See https://forum.golangbridge.org/t/go-get-marking-go-mod-incompatible/10686 for more.