### PR TITLE
Fall back to ParseTolerant in UnmarshalJSON

### DIFF
--- a/json.go
+++ b/json.go
@@ -18,6 +18,10 @@ func (v *Version) UnmarshalJSON(data []byte) (err error) {
 	}
 
 	*v, err = Parse(versionString)
+	if err != nil {
+		*v, err = ParseTolerant(versionString)
+		return
+	}
 
 	return
 }

--- a/json_test.go
+++ b/json_test.go
@@ -43,7 +43,18 @@ func TestJSONUnmarshal(t *testing.T) {
 		t.Fatal("expected JSON unmarshal error, got nil")
 	}
 
-	if err := json.Unmarshal([]byte("3.1"), &v); err == nil {
-		t.Fatal("expected JSON unmarshal error, got nil")
+	noMinorOrPatchVersionString := strconv.Quote("3")
+	if err := json.Unmarshal([]byte(noMinorOrPatchVersionString), &v); err != nil {
+		t.Fatal(err)
+	}
+
+	noPatchVersionString := strconv.Quote("3.1")
+	if err := json.Unmarshal([]byte(noPatchVersionString), &v); err != nil {
+		t.Fatal(err)
+	}
+
+	fullVersionString := strconv.Quote("3.2.1")
+	if err := json.Unmarshal([]byte(fullVersionString), &v); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/json_test.go
+++ b/json_test.go
@@ -57,4 +57,14 @@ func TestJSONUnmarshal(t *testing.T) {
 	if err := json.Unmarshal([]byte(fullVersionString), &v); err != nil {
 		t.Fatal(err)
 	}
+
+	prefixVVersionString := strconv.Quote("v3.2")
+	if err := json.Unmarshal([]byte(prefixVVersionString), &v); err != nil {
+		t.Fatal(err)
+	}
+
+	trailingWhitespaceString := strconv.Quote("  v3.2.1   ")
+	if err := json.Unmarshal([]byte(trailingWhitespaceString), &v); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "license": "MIT",
   "name": "semver",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "3.5.1"
+  "version": "3.5.2"
 }
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "license": "MIT",
   "name": "semver",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "3.5.2"
+  "version": "3.5.1"
 }
 


### PR DESCRIPTION
See https://github.com/blang/semver/issues/16 and https://github.com/blang/semver/pull/19 for context

I've extended the UnmarshalJSON to fall back to ParseTolerant if there is an error on Parse. If that errors too then the error is returned.

I added test cases for this that are all passing well.

This allows me to build a struct like this and have it parse automatically:

```go
type Fields struct {
	AppVersion semver.Version `json:"app_version"`
	OSVersion  semver.Version `json:"os_version"`
	FooBar     string         `json:"foobar"`
}
```

This now works with my mobile clients, which version like `4.5` rather than `4.5.0` which there's no way for me to fix historically.