### PR TITLE
Fix ParseTolerant when zeros are continuous

### DIFF
--- a/semver.go
+++ b/semver.go
@@ -243,7 +243,11 @@ func ParseTolerant(s string) (Version, error) {
 	// Remove leading zeros.
 	for i, p := range parts {
 		if len(p) > 1 {
-			parts[i] = strings.TrimPrefix(p, "0")
+			p = strings.TrimLeft(p, "0")
+			if len(p) == 0 || !strings.ContainsAny(p[0:1], "0123456789") {
+				p = "0" + p
+			}
+			parts[i] = p
 		}
 	}
 	// Fill up shortened versions.

--- a/semver_test.go
+++ b/semver_test.go
@@ -32,9 +32,12 @@ var formatTests = []formatTest{
 
 var tolerantFormatTests = []formatTest{
 	{Version{1, 2, 3, nil, nil}, "v1.2.3"},
+	{Version{1, 2, 0, []PRVersion{prstr("alpha")}, nil}, "1.2.0-alpha"},
+	{Version{1, 2, 0, nil, nil}, "1.2.00"},
 	{Version{1, 2, 3, nil, nil}, "	1.2.3 "},
 	{Version{1, 2, 3, nil, nil}, "01.02.03"},
 	{Version{0, 0, 3, nil, nil}, "00.0.03"},
+	{Version{0, 0, 3, nil, nil}, "000.0.03"},
 	{Version{1, 2, 0, nil, nil}, "1.2"},
 	{Version{1, 0, 0, nil, nil}, "1"},
 }


### PR DESCRIPTION
It fixes #55. This is a serious bug, so I want you to respond early.