### PR TITLE
Update go.mod to stick to go 1.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/blang/semver
+
+go 1.12


### PR DESCRIPTION
The go version should be pinned in order to avoid incompatibilities for the now and the future.