### PR TITLE
[FEAT]: added Ranger as alternative to Range

### DIFF
--- a/v4/range.go
+++ b/v4/range.go
@@ -31,6 +31,10 @@ func wildcardTypefromInt(i int) wildcardType {
 	}
 }
 
+//----------------------------------------------------------------------------------------------------------//
+//
+//----------------------------------------------------------------------------------------------------------//
+
 type comparator uint8
 
 const (
@@ -100,6 +104,10 @@ func (c comparator) String() string {
 	}
 }
 
+//----------------------------------------------------------------------------------------------------------//
+//
+//----------------------------------------------------------------------------------------------------------//
+
 type versionRange struct {
 	v Version
 	c comparator
@@ -115,27 +123,6 @@ func (vr *versionRange) String() string {
 }
 
 // Range represents a range of versions.
-// A Range can be used to check if a Version satisfies it:
-//
-//     range, err := semver.ParseRange(">1.0.0 <2.0.0")
-//     range(semver.MustParse("1.1.1") // returns true
-type Range func(Version) bool
-
-// OR combines the existing Range with another Range using logical OR.
-func (rf Range) OR(f Range) Range {
-	return Range(func(v Version) bool {
-		return rf(v) || f(v)
-	})
-}
-
-// AND combines the existing Range with another Range using logical AND.
-func (rf Range) AND(f Range) Range {
-	return Range(func(v Version) bool {
-		return rf(v) && f(v)
-	})
-}
-
-// Range rrepresents a range of versions.
 // Ranger is slightly different from Range, that it can be converted back to string.
 // A Ranger can be used to check if a Version satisfies it:
 //
@@ -187,6 +174,15 @@ func (r orRange) String() string {
 	return strings.Join(strs, " || ")
 }
 
+// MustParseRange is like ParseRange but panics if the range cannot be parsed.
+func MustParseRange(s string) Ranger {
+	r, err := ParseRange(s)
+	if err != nil {
+		panic(`semver: ParseRange(` + s + `): ` + err.Error())
+	}
+	return r
+}
+
 // ParseRange parses a range and returns a Range.
 // If the range could not be parsed an error is returned.
 //
@@ -211,16 +207,7 @@ func (r orRange) String() string {
 // Ranges can be combined by both AND and OR
 //
 //  - `>1.0.0 <2.0.0 || >3.0.0 !4.2.1` would match `1.2.3`, `1.9.9`, `3.1.1`, but not `4.2.1`, `2.1.1`
-func ParseRange(s string) (Range, error) {
-	ranger, err := ParseRanger(s)
-	if err != nil {
-		return nil, err
-	}
-
-	return ranger.Range, nil
-}
-
-func ParseRanger(s string) (Ranger, error) {
+func ParseRange(s string) (Ranger, error) {
 	parts := splitAndTrim(s)
 	orParts, err := splitORParts(parts)
 	if err != nil {
@@ -489,11 +476,9 @@ func expandWildcardVersion(parts [][]string) ([][]string, error) {
 	return expandedParts, nil
 }
 
-// MustParseRange is like ParseRange but panics if the range cannot be parsed.
-func MustParseRange(s string) Range {
-	r, err := ParseRange(s)
-	if err != nil {
-		panic(`semver: ParseRange(` + s + `): ` + err.Error())
-	}
-	return r
+type wildcardSemver struct {
+	Major int
+	Minor int
+	Patch int
+	PR    []PRVersion
 }

--- a/v4/range_test.go
+++ b/v4/range_test.go
@@ -34,7 +34,7 @@ func TestParseComparator(t *testing.T) {
 	}
 
 	for _, tc := range compatorTests {
-		if c := parseComparator(tc.input); c == nil {
+		if c := parseComparator(tc.input); c == compInvalid {
 			if tc.comparator != nil {
 				t.Errorf("Comparator nil for case %q\n", tc.input)
 			}
@@ -51,27 +51,27 @@ var (
 )
 
 func testEQ(f comparator) bool {
-	return f(v1, v1) && !f(v1, v2)
+	return f.compare(v1, v1) && !f.compare(v1, v2)
 }
 
 func testNE(f comparator) bool {
-	return !f(v1, v1) && f(v1, v2)
+	return !f.compare(v1, v1) && f.compare(v1, v2)
 }
 
 func testGT(f comparator) bool {
-	return f(v2, v1) && f(v3, v2) && !f(v1, v2) && !f(v1, v1)
+	return f.compare(v2, v1) && f.compare(v3, v2) && !f.compare(v1, v2) && !f.compare(v1, v1)
 }
 
 func testGE(f comparator) bool {
-	return f(v2, v1) && f(v3, v2) && !f(v1, v2)
+	return f.compare(v2, v1) && f.compare(v3, v2) && !f.compare(v1, v2)
 }
 
 func testLT(f comparator) bool {
-	return f(v1, v2) && f(v2, v3) && !f(v2, v1) && !f(v1, v1)
+	return f.compare(v1, v2) && f.compare(v2, v3) && !f.compare(v2, v1) && !f.compare(v1, v1)
 }
 
 func testLE(f comparator) bool {
-	return f(v1, v2) && f(v2, v3) && !f(v2, v1)
+	return f.compare(v1, v2) && f.compare(v2, v3) && !f.compare(v2, v1)
 }
 
 func TestSplitAndTrim(t *testing.T) {
@@ -157,7 +157,7 @@ func TestBuildVersionRange(t *testing.T) {
 				t.Errorf("Invalid for case %q: Expected version %q, got: %q", strings.Join([]string{tc.opStr, tc.vStr}, ""), tv, r.v)
 			}
 			// test comparator
-			if r.c == nil {
+			if r.c == compInvalid {
 				t.Errorf("Invalid for case %q: got nil comparator", strings.Join([]string{tc.opStr, tc.vStr}, ""))
 				continue
 			}
@@ -299,8 +299,7 @@ func TestVersionRangeToRange(t *testing.T) {
 		v: MustParse("1.2.3"),
 		c: compLT,
 	}
-	rf := vr.rangeFunc()
-	if !rf(MustParse("1.2.2")) || rf(MustParse("1.2.3")) {
+	if !vr.Range((MustParse("1.2.2"))) || vr.Range(MustParse("1.2.3")) {
 		t.Errorf("Invalid conversion to range func")
 	}
 }


### PR DESCRIPTION
Main differences between `Range`:

* compiled version checker can be reverted back to string, if necessary
* possibly, you can add support of inner comparison (in rounded brackets -> `()`, like in mathematical operations), as well as additional comparators, or range syntax (got a few ideas from [this article](https://blog.greenkeeper.io/introduction-to-version-ranges-e0e8c6c85f0f))

My main goal was to revert back parsed range, so possibly we can optimize it a bit without loosing backward compatibility.