### PR TITLE
Allow prereleases to contain x

### DIFF
--- a/v4/range.go
+++ b/v4/range.go
@@ -327,12 +327,13 @@ func expandWildcardVersion(parts [][]string) ([][]string, error) {
 	for _, p := range parts {
 		var newParts []string
 		for _, ap := range p {
-			if strings.Contains(ap, "x") {
-				opStr, vStr, err := splitComparatorVersion(ap)
-				if err != nil {
-					return nil, err
-				}
+			
+			opStr, vStr, err := splitComparatorVersion(ap)
+			if err != nil {
+				return nil, err
+			}
 
+			if strings.Contains(ap, ".x") {
 				versionWildcardType := getWildcardType(vStr)
 				flatVersion := createVersionFromWildcard(vStr)
 

--- a/v4/range_test.go
+++ b/v4/range_test.go
@@ -272,6 +272,7 @@ func TestExpandWildcardVersion(t *testing.T) {
 		o [][]string
 	}{
 		{[][]string{{"foox"}}, nil},
+		{[][]string{{"0.1.0-x"}}, [][]string{{"0.1.0-x"}}},
 		{[][]string{{">=1.2.x"}}, [][]string{{">=1.2.0"}}},
 		{[][]string{{"<=1.2.x"}}, [][]string{{"<1.3.0"}}},
 		{[][]string{{">1.2.x"}}, [][]string{{">=1.3.0"}}},
@@ -484,6 +485,9 @@ func TestParseRange(t *testing.T) {
 			{"2.0.1", true},
 			{"2.9.9", true},
 			{"3.0.0", false},
+		}},
+		{"0.1.0-x", []tv{
+			{"0.1.0-x", true},
 		}},
 	}
 


### PR DESCRIPTION
Closes #75 

This pull request slightly alters `expandWildcardVersions` to use `strings.Contains(.x)` instead of `strings.Contains(x)` for trying to assess whether a range condition has a wildcard. This allows prereleases with `x` in the name as opposed to failing with the error documented in #75: `Could not get version from string: "<"`.


